### PR TITLE
move to tree-sitter-bash

### DIFF
--- a/coverage_sh/plugin.py
+++ b/coverage_sh/plugin.py
@@ -22,11 +22,10 @@ from typing import TYPE_CHECKING, Any, Iterable, Iterator
 import coverage
 import magic
 from coverage import CoveragePlugin, FileReporter, FileTracer
-from tree_sitter_languages import get_parser
 
 if TYPE_CHECKING:
     from coverage.types import TLineNo
-    from tree_sitter import Node
+    from tree_sitter import Node, Parser
 
 if sys.version_info < (3, 9):
     from typing import Dict, Set
@@ -59,13 +58,22 @@ SUPPORTED_MIME_TYPES = {"text/x-shellscript"}
 
 
 class ShellFileReporter(FileReporter):
+    _parser: Parser
+
     def __init__(self, filename: str) -> None:
         super().__init__(filename)
 
         self.path = Path(filename)
         self._content: str | None = None
         self._executable_lines: set[int] = set()
-        self._parser = get_parser("bash")
+        self._init_parser()
+
+    def _init_parser(self) -> None:
+        import tree_sitter_bash
+        from tree_sitter import Language, Parser
+
+        language = Language(tree_sitter_bash.language())
+        self._parser = Parser(language)
 
     def source(self) -> str:
         if self._content is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ authors = [
 dependencies = [
     "coverage>=7.3.3",
     "python-magic>=0.4.27",
-    "tree-sitter-languages>=1.8.0",
+    "tree-sitter>=0.22.0",
+    "tree-sitter-bash",
 ]
 readme = "README.md"
 requires-python = ">= 3.8"
@@ -39,7 +40,6 @@ dev-dependencies = [
     "mypy>=1.9.0",
     "pytest>=7.4.3",
     "setuptools>=69.0.2",
-    "types-tree-sitter-languages>=1.10.0.20240201",
 ]
 
 [tool.hatch.metadata]


### PR DESCRIPTION
Current version relies on unmaintained tree-sitter-language which is large and does not support tree-sitter>=0.22

Migrate to tree-sitter-bash, including API changes. Since this is a library use the widest possible dependency range

Attempts to fix https://github.com/lackhove/coverage-sh/issues/20