### PR TITLE
.vscode/settings.json: enable pytest

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": [
+        "tests"
+    ]
+}


### PR DESCRIPTION
This makes the vscode test plugin "just work" by default.

Some projects don't like having such IDE files inside the code so you can reject this and I will handle it locally. But I think it makes sense to have it.