### PR TITLE
pre-commit: add

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.8
+    hooks:
+      - id: ruff-check
+      - id: ruff-format


### PR DESCRIPTION
Run `pre-commit install` and ruff check/format will be checked on every git commit.

Catching this locally is preferable to CI failures because it's faster.

See: https://pre-commit.com/
See: https://github.com/astral-sh/ruff-pre-commit