### PR TITLE
Fix hang on shutdown when asyncio.create_subprocess is used

### DIFF
--- a/coverage_sh/plugin.py
+++ b/coverage_sh/plugin.py
@@ -282,9 +282,9 @@ class PatchedPopen(OriginalPopen):  # type: ignore[type-arg]
         super().__init__(**kwargs)
 
     def wait(self, timeout: float | None = None) -> int:
-        retval = super().wait(timeout)
+        result = super().wait(timeout)
         self._clean_helper()
-        return retval
+        return result
 
     def _clean_helper(self) -> None:
         if self._parser_thread is None:

--- a/coverage_sh/plugin.py
+++ b/coverage_sh/plugin.py
@@ -283,15 +283,16 @@ class PatchedPopen(OriginalPopen):  # type: ignore[type-arg]
 
     def wait(self, timeout: float | None = None) -> int:
         retval = super().wait(timeout)
-        if self._parser_thread is None:
-            # no coverage recording was active during __init__
-            return retval
+        self._clean_helper()
+        return retval
 
+    def _clean_helper(self) -> None:
+        if self._parser_thread is None:
+            return
         self._parser_thread.stop()
         self._parser_thread.join()
         with contextlib.suppress(FileNotFoundError):
             self._helper_path.unlink()
-        return retval
 
 
 class MonitorThread(threading.Thread):

--- a/coverage_sh/plugin.py
+++ b/coverage_sh/plugin.py
@@ -286,6 +286,16 @@ class PatchedPopen(OriginalPopen):  # type: ignore[type-arg]
         self._clean_helper()
         return result
 
+    def poll(self) -> int | None:
+        result = super().poll()
+        if result is not None:
+            self._clean_helper()
+        return result
+
+    def __del__(self) -> None:
+        super().__del__()
+        self._clean_helper()
+
     def _clean_helper(self) -> None:
         if self._parser_thread is None:
             return

--- a/tests/resources/testproject/main_async.py
+++ b/tests/resources/testproject/main_async.py
@@ -1,0 +1,11 @@
+import asyncio
+
+
+async def main() -> None:
+    proc = await asyncio.create_subprocess_exec("./test.sh")
+    _stdout, _stderr = await proc.communicate()
+    assert proc.returncode == 0
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -281,6 +281,35 @@ patch = ["subprocess"]
     )
 
 
+def test_end2end_async_simple(dummy_project_dir: Path) -> None:
+    """
+    Test creating subprocess via asyncio
+
+    This used to hang without PatchedPopen.__del__ patching
+    """
+    argv = [sys.executable, "-m", "coverage", "run", "--parallel", "main_async.py"]
+    proc = subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=END2END_SUBPROCESS_TIMEOUT,
+        cwd=str(dummy_project_dir),
+    )
+    assert proc.stdout == END2END_STDOUT
+    subprocess.check_call(
+        [sys.executable, "-m", "coverage", "combine"],
+        cwd=str(dummy_project_dir),
+    )
+    subprocess.check_call(
+        [sys.executable, "-m", "coverage", "json"],
+        cwd=str(dummy_project_dir),
+    )
+    coverage_json = json.loads(dummy_project_dir.joinpath("coverage.json").read_text())
+    assert coverage_json["files"]["main_async.py"]
+    assert coverage_json["files"]["test.sh"]["executed_lines"] == [8, 9, 10]
+
+
 class TestShellFileReporter:
     @pytest.fixture
     def reporter(self, syntax_example_path: Path) -> ShellFileReporter:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -143,6 +143,9 @@ END2END_STDOUT = SYNTAX_EXAMPLE_STDOUT + "Hello from inner python\n"
 #: lines executed inside inner.py
 INNER_PY_EXECUTED_LINES = [2]
 
+#: timeout for running end2end tests
+END2END_SUBPROCESS_TIMEOUT = 5
+
 
 @pytest.fixture
 def examples_dir(resources_dir: Path) -> Path:
@@ -178,7 +181,7 @@ def test_end2end(
         capture_output=True,
         text=True,
         check=True,
-        timeout=2,
+        timeout=END2END_SUBPROCESS_TIMEOUT,
     )
 
     if sys.version_info < (3, 14):
@@ -264,7 +267,7 @@ patch = ["subprocess"]
         capture_output=True,
         text=True,
         check=True,
-        timeout=2,
+        timeout=END2END_SUBPROCESS_TIMEOUT,
     )
     if sys.version_info < (3, 14):
         # we raise a warning when sysmon run.core is set to sysmon, which is the default since 3.14

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -487,6 +487,22 @@ class TestPatchedPopen:
         assert proc.stdout is not None
         assert proc.stdout.read() == END2END_STDOUT
 
+    def test_wait_poll_notyet(self) -> None:
+        proc = PatchedPopen(
+            ["/bin/bash", "-c", "read;echo $REPLY"],
+            stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+        )
+        assert proc.poll() is None
+        with pytest.raises(subprocess.TimeoutExpired):
+            proc.wait(0.1)
+        out, err = proc.communicate(b"aaa")
+        assert out == b"aaa\n"
+        assert err is None
+        assert proc.returncode == 0
+        assert proc.poll() == 0
+        assert proc.wait() == 0
+
 
 class TestMonitorThread:
     class MainThreadStub:


### PR DESCRIPTION
Fixes #41  - can now using asyncio.create_subprocess while coverage_sh is enabled.

As far as I can tell asyncio.create_subprocess will initialize a `subprocess.Popen` object internally and use it with a custom PID waiter, skipping `Popen.wait` and `Popen.poll`. I was only able to get this to work by hooking into `Popen.__del__`.

There are other use cases where hooking `Popen.__del__` is useful, for example if the user simply leaks a `subprocess.Popen` that shouldn't cause coverage_sh threads to simple hang.

It might make sense to also mark `CoverageParserThread` as a daemon thread. This shouldn't replace the `__del__` hook because then threads would leak until main process exit.

Includes a new `test_end2end_async_simple` which does coverage on a new `main_async.py` script which calls `asyncio.create_subprocess`. Without `PatchedPopen.__del__` it hangs - demonstrating the original issue. It also surprisingly shows that coverage works as expected!