### PR TITLE
Fix pre-commit by removing the mypy hook

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -103,3 +103,15 @@ jobs:
           minColorRange: 50
           maxColorRange: 90
           valColorRange: ${{ env.total }}
+
+
+  pre-commit:
+    name: Run pre-commit hooks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -103,15 +103,3 @@ jobs:
           minColorRange: 50
           maxColorRange: 90
           valColorRange: ${{ env.total }}
-
-
-  pre-commit:
-    name: Run pre-commit hooks
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version-file: .python-version
-      - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,3 @@ repos:
     hooks:
       - id: ruff-check
       - id: ruff-format
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.19.0'
-    hooks:
-    -   id: mypy


### PR DESCRIPTION
This does not currently work because pre-commit executes hooks in a private venv and mypy requires the projects own dependencies.

It's possible to make this pass by duplicating dependencies into the pre-commit config file but it is not worth it.

Also run pre-commit inside github to ensure config is always appropriate.