### PR TITLE
plugin: remove subshell and pipeline from EXECUTABLE_NODE_TYPES

### DIFF
--- a/coverage_sh/plugin.py
+++ b/coverage_sh/plugin.py
@@ -37,7 +37,6 @@ LineData = dict[str, set[int]]
 TMP_PATH = Path(os.environ.get("XDG_RUNTIME_DIR", "/tmp"))  # noqa: S108
 TRACEFILE_PREFIX = "shelltrace"
 EXECUTABLE_NODE_TYPES = {
-    "subshell",
     "redirected_statement",
     "variable_assignment",
     "variable_assignments",

--- a/coverage_sh/plugin.py
+++ b/coverage_sh/plugin.py
@@ -50,7 +50,6 @@ EXECUTABLE_NODE_TYPES = {
     "while_statement",
     "if_statement",
     "case_statement",
-    "pipeline",
     "list",
 }
 SUPPORTED_MIME_TYPES = {"text/x-shellscript"}

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -248,6 +248,30 @@ class TestShellFileReporter:
             pytest.param(
                 "case x in\n  x) echo match ;;\nesac\n", {2, 3}, id="esac_excluded"
             ),
+            pytest.param(
+                """\
+                echo aaa
+                func()
+                {
+                    echo bbb
+                }
+                func
+                """,
+                {2, 5, 7},
+                id="func_brace",
+            ),
+            pytest.param(
+                """\
+                echo aaa
+                func()
+                (
+                    echo aaa
+                )
+                func
+                """,
+                {2, 5, 7},
+                id="func_paren",
+            ),
         ],
     )
     def test_executable_lines(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -272,6 +272,17 @@ class TestShellFileReporter:
                 {2, 5, 7},
                 id="func_paren",
             ),
+            pytest.param(
+                """\
+                {
+                    echo aaa
+                    # comment
+                    echo bbb
+                } | grep a
+                """,
+                {3, 5, 6},
+                id="long_pipeline",
+            ),
         ],
     )
     def test_executable_lines(


### PR DESCRIPTION
A "subshell" is a container for executable commands but is not by itself executable. Treat it just like "compound_statement".

Same logic applies to "pipeline". Removing this fixes incorrectly reported uncovered first line in following example:

```
{
    echo aaa
    # comment
    echo bbb
} | grep a
```

Fixes #48