### PR TITLE
remove python-magic dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,8 +134,7 @@ def test_something(cover_always: bool) -> None:
 
 - **Single-module plugin:** all production logic is in `coverage_sh/plugin.py`;
   `coverage_sh/__init__.py` is only a registration entry point
-- **File detection:** uses `python-magic` (libmagic) MIME type detection
-  (`text/x-shellscript`), not file extensions — do not assume `.sh` == shell script
+- **File detection:** based on extension or shebang
 - **Two coverage modes:** subprocess monkey-patching (default) and `cover_always` mode
   (sets `BASH_ENV`/`ENV` globally)
 - **FIFO pipeline:** bash processes write `COV:::<path>:::<lineno>:::` lines via

--- a/coverage_sh/plugin.py
+++ b/coverage_sh/plugin.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import contextlib
 import inspect
 import os
+import re
 import selectors
 import stat
 import string
@@ -20,7 +21,6 @@ from time import sleep
 from typing import TYPE_CHECKING, Any, cast
 from warnings import warn
 
-import magic
 import tree_sitter_bash
 from coverage import Coverage, CoverageData, CoveragePlugin, FileReporter, FileTracer
 from tree_sitter import Language, Parser
@@ -52,7 +52,75 @@ EXECUTABLE_NODE_TYPES = {
     "case_statement",
     "list",
 }
-SUPPORTED_MIME_TYPES = {"text/x-shellscript"}
+
+# path.suffix for typical shell filenames
+_SHELL_FILE_SUFFIXES = {".bash", ".csh", ".dash", ".ksh", ".sh", ".tcsh", ".zsh"}
+
+# Interpreter names recognized in a shebang, after #!
+_SHELL_INTERPRETERS = {"ash", "bash", "csh", "dash", "fish", "ksh", "sh", "tcsh", "zsh"}
+
+# First line reads as a non-shell language throughout (e.g. Python in a *.sh file).
+_RE_NON_SHELL_FIRST_LINE = re.compile(
+    r"^\s*(?:def\s|import\s|from\s|class\s|async\s+def\s|@\w|'''|\"\"\")",
+)
+
+
+def _shebang_names_shell(rest: str) -> bool:
+    """Return whether the shebang body (text after ``#!``) invokes a shell."""
+    parts = rest.split()
+    if not parts:
+        return False
+    names = [part.rsplit("/", 1)[-1] for part in parts]
+    if names[0] in {"busybox", "env"}:
+        return len(names) > 1 and names[1] in _SHELL_INTERPRETERS
+    return names[0] in _SHELL_INTERPRETERS
+
+
+def _read_first_line(path: Path) -> str | None:
+    try:
+        with path.open("rb") as fh:
+            chunk = fh.read(4096)
+    except OSError:
+        return None
+    if not chunk:
+        return None
+    text = chunk.decode("utf-8", errors="replace")
+    return text.splitlines()[0]
+
+
+def _is_shell_script_header(first_line: str) -> bool | None:
+    """
+    Classify the first line for shell-script detection.
+
+    Returns ``True`` for a shell-style shebang. Returns ``False`` when it
+    clearly belongs to another language, otherwise return ``None``.
+    """
+    head = first_line.strip()
+    if head.startswith("#!"):
+        rest = head[2:].strip()
+        return _shebang_names_shell(rest)
+    if _RE_NON_SHELL_FIRST_LINE.match(first_line):
+        return False
+    return None
+
+
+def _is_shell_script_filename(path: Path) -> bool:
+    return path.suffix.lower() in _SHELL_FILE_SUFFIXES
+
+
+def _is_shell_script(path: Path) -> bool:
+    """
+    Guess if the file is a shell script
+
+    Returns ``True`` if first line has a shell-style shebang, or if filename has
+    a shell-like suffix and this is not ruled out by the first line.
+    """
+    first_line = _read_first_line(path) or ""
+    header = _is_shell_script_header(first_line)
+    if header is True:
+        return True
+    return _is_shell_script_filename(path) and header is not False
+
 
 PLUGIN_DEBUG_OPTION = "shell"
 
@@ -409,7 +477,7 @@ class ShellPlugin(CoveragePlugin):
 
     @staticmethod
     def _is_relevant(path: Path) -> bool:
-        return magic.from_file(path.resolve(), mime=True) in SUPPORTED_MIME_TYPES
+        return _is_shell_script(path.resolve())
 
     def file_tracer(self, filename: str) -> FileTracer | None:  # noqa: ARG002
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [
 ]
 dependencies = [
     "coverage>=7.3.3",
-    "python-magic>=0.4.27",
     "tree-sitter>=0.22.0",
     "tree-sitter-bash",
 ]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -651,7 +651,7 @@ class TestShellPlugin:
     def test_find_executable_files_should_find_shell_files(
         self, tmp_path: Path
     ) -> None:
-        # A shell script with a non-standard extension — detected by MIME type
+        # A shell script with a non-standard extension — detected via shebang
         (tmp_path / "shell-file.weird.suffix").write_text("#!/bin/bash\necho hi\n")
         # A .sh file that contains Python — should NOT be detected as shell
         (tmp_path / "non-bash-file.sh").write_text("def main(): pass\n")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -31,6 +31,7 @@ from coverage_sh.plugin import (
     PatchedPopen,
     ShellFileReporter,
     ShellPlugin,
+    _is_shell_script,
     debug_write,
     filename_suffix,
 )
@@ -635,6 +636,74 @@ class TestMonitorThread:
             main_thread=cast("threading.Thread", self.MainThreadStub()),
         )
         monitor_thread.start()
+
+
+class TestShellScriptDetection:
+    @pytest.mark.parametrize(
+        ("filename", "content", "expected"),
+        [
+            ("file.txt", "#!/bin/sh\n", True),
+            ("file.txt", "#!/bin/bash", True),
+            ("file.txt", "#!/usr/bin/env bash\n", True),
+            ("file.txt", "#!/bin/dash", True),
+            ("file.txt", "#!/usr/bin/env zsh\n", True),
+            ("file.txt", "#!/bin/busybox ash\n", True),
+            ("file.txt", "  #!  /bin/ksh  \n", True),
+            ("file.txt", "#!/usr/bin/python3", False),
+            ("file.txt", "#!/usr/bin/env python", False),
+            ("file.txt", "#!/usr/bin/env ruby", False),
+            ("script.sh", "def main(): pass\n", False),
+            ("script.sh", "import os\n", False),
+            ("script.sh", "from pathlib import Path\n", False),
+            ("script.sh", "class Spam:\n", False),
+            ("script.sh", "async def foo() -> None:\n", False),
+            ("script.sh", "echo 'no shebang'\n", True),
+            ("script.sh", "# just a comment\n", True),
+            ("script.sh", "set -euo pipefail\n", True),
+            ("file.txt", "echo 'no shebang'\n", False),
+            ("file.txt", "# just a comment\n", False),
+            ("file.txt", "set -euo pipefail\n", False),
+            ("script.sh", "echo hi\n", True),
+            ("setup.bash", "echo hi\n", True),
+            ("Profile.zsh", "echo hi\n", True),
+            ("foo.DASH", "echo hi\n", True),
+            ("legacy.TCSH", "echo hi\n", True),
+            ("module.py", "echo hi\n", False),
+            ("README", "echo hi\n", False),
+            ("archive.tar.gz", "echo hi\n", False),
+            ("two-part.sh.bak", "echo hi\n", False),
+            ("empty-script.sh", "", True),
+            ("empty-text.txt", "", False),
+            ("spaces.txt", "   ", False),
+            ("empty-shebang.py", "#!  \n", False),
+        ],
+    )
+    def test_is_shell_script(
+        self,
+        tmp_path: Path,
+        filename: str,
+        content: str,
+        expected: bool,
+    ) -> None:
+        path = tmp_path / filename
+        path.write_text(content)
+        assert _is_shell_script(path) is expected
+
+    @pytest.mark.parametrize(
+        ("filename", "expected"),
+        [
+            ("file.txt", False),
+            ("file.sh", True),
+        ],
+    )
+    def test_is_shell_script_when_read_fails(
+        self,
+        tmp_path: Path,
+        filename: str,
+        expected: bool,
+    ) -> None:
+        path = tmp_path / filename
+        assert _is_shell_script(path) is expected
 
 
 class TestShellPlugin:

--- a/uv.lock
+++ b/uv.lock
@@ -252,7 +252,6 @@ source = { editable = "." }
 dependencies = [
     { name = "coverage", version = "7.10.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "coverage", version = "7.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "python-magic" },
     { name = "tree-sitter", version = "0.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "tree-sitter", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "tree-sitter-bash", version = "0.23.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -271,7 +270,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "coverage", specifier = ">=7.3.3" },
-    { name = "python-magic", specifier = ">=0.4.27" },
     { name = "tree-sitter", specifier = ">=0.22.0" },
     { name = "tree-sitter-bash" },
 ]
@@ -554,15 +552,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
-]
-
-[[package]]
-name = "python-magic"
-version = "0.4.27"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b", size = 14677, upload-time = "2022-06-07T20:16:59.508Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3", size = 13840, upload-time = "2022-06-07T20:16:57.763Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The python-magic package depends on the native libmagic library. This dependency needs to be added in containers and such.

Replace `import magic` with manual checks based on filename extension and header.

If people have trouble with auto-detect logic the best bet would be to add a shebang, even for non-executable library files. This is also used by shellcheck.